### PR TITLE
fix deprecated warning message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,38 +1,38 @@
 {
-    "name": "gitbook-restructuredtext",
-    "version": "0.2.3",
-    "homepage": "https://www.gitbook.com",
-    "description": "Parse reStructuredText content for gitbook",
-    "main": "lib/index.js",
-    "dependencies": {
-        "q": "^1.1.2",
-        "lodash": "^3.2.0",
-        "cheerio": "^0.19.0",
-        "tmp": "0.0.24"
+  "name": "gitbook-restructuredtext",
+  "version": "0.2.3",
+  "homepage": "https://www.gitbook.com",
+  "description": "Parse reStructuredText content for gitbook",
+  "main": "lib/index.js",
+  "dependencies": {
+    "cheerio": "^0.22.0",
+    "lodash": "^4.17.2",
+    "q": "^1.1.2",
+    "tmp": "0.0.30"
+  },
+  "devDependencies": {
+    "mocha": "^3.1.2"
+  },
+  "scripts": {
+    "test": "export TESTING=true; mocha --reporter list"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GitbookIO/gitbook-restructuredtext.git"
+  },
+  "author": "FriendCode Inc. <contact@gitbook.com>",
+  "license": "Apache 2",
+  "bugs": {
+    "url": "https://github.com/GitbookIO/gitbook-restructuredtext/issues"
+  },
+  "contributors": [
+    {
+      "name": "Aaron O'Mullan",
+      "email": "aaron@gitbook.com"
     },
-    "devDependencies": {
-        "mocha": "1.18.2"
-    },
-    "scripts": {
-        "test": "export TESTING=true; mocha --reporter list"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/GitbookIO/gitbook-restructuredtext.git"
-    },
-    "author": "FriendCode Inc. <contact@gitbook.com>",
-    "license": "Apache 2",
-    "bugs": {
-        "url": "https://github.com/GitbookIO/gitbook-restructuredtext/issues"
-    },
-    "contributors": [
-        {
-            "name": "Aaron O'Mullan",
-            "email": "aaron@gitbook.com"
-        },
-        {
-            "name": "Samy Pessé",
-            "email": "samy@gitbook.com"
-        }
-    ]
+    {
+      "name": "Samy Pessé",
+      "email": "samy@gitbook.com"
+    }
+  ]
 }


### PR DESCRIPTION
Hi, I have fixed following deprecated warging on Node.js v7.1.0

```
(node:13061) DeprecationWarning: child_process: options.customFds option is deprecated. Use options.stdio instead.

(node:13062) DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.
```

Updated modules:

```
┌─────────┬─────────┬────────┐
│ Name    │ Before  │ After  │
├─────────┼─────────┼────────┤
│ lodash  │  3.2.0  │ 4.17.2 │
├─────────┼─────────┼────────┤
│ tmp     │ 0.0.24  │ 0.0.30 │
├─────────┼─────────┼────────┤
│ cheerio │ 0.19.0  │ 0.22.0 │
├────--───┼─────────┼────────┤
│ mocha   │ 1.18.2  │ 3.1.2  │
└─────────┴─────────┴────────┘
```